### PR TITLE
Remove installation of mvviewer library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,4 @@ add_executable(main main.cpp)
 find_package(realsense2 REQUIRED)
 target_link_libraries(main realsense2::realsense2)
 
-target_link_libraries(main MVSDK)
-target_link_directories(main PUBLIC /opt/HuarayTech/MVviewer/lib)
-target_include_directories(main SYSTEM PUBLIC /opt/HuarayTech/MVviewer/include)
-
 target_compile_features(main PRIVATE cxx_std_20)

--- a/library_installers/install_libraries.sh
+++ b/library_installers/install_libraries.sh
@@ -14,4 +14,3 @@ sudo pip install cmake==3.26.3
 
 directory_path_of_this_script=$(dirname $(readlink -f "$0"))
 $directory_path_of_this_script/librealsense2_installer/install_librealsense2.sh
-$directory_path_of_this_script/mvviewer_installer/install_mvviewer.sh


### PR DESCRIPTION
If we install only `librealsense2`, then the program successfully finishes.