### PR TITLE
Disable test for Ubuntu 22.04

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,10 +4,7 @@ on: [push]
 
 jobs:
   build-linux-gcc:
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently `librealsense2` does not support Ubuntu 24.04.